### PR TITLE
Allow backend on port 8019 in dev

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -3,7 +3,7 @@ import type { NextConfig } from "next";
 const nextConfig = {
   experimental: {
     allowedDevOrigins: [
-      "http://classwork.engr.oregonstate.edu:8010", // Your Go backend origin
+      "http://classwork.engr.oregonstate.edu:8019", // Your Go backend origin
       "http://classwork.engr.oregonstate.edu:3004", // Your frontend dev server
     ],
   },

--- a/server/main.go
+++ b/server/main.go
@@ -152,6 +152,6 @@ func main() {
 	// Specifying that the rounter will be handled with CORS middleware.
 	handlerWithCORS := c.Handler(r)
 
-	// Middleware serves from port 8010, logs failure.
+	// Middleware serves from port 8019, logs failure.
 	log.Fatal(http.ListenAndServe(":8019", handlerWithCORS))
 }


### PR DESCRIPTION
## Summary
- update Next.js dev config to allow backend on port 8019
- fix server comment to match port 8019

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`
- `cd server && go build`

------
https://chatgpt.com/codex/tasks/task_e_689e13df5bf483298d482b0685bbee11